### PR TITLE
fix calls to collect anchors

### DIFF
--- a/atlas_df/anchoring.py
+++ b/atlas_df/anchoring.py
@@ -14,8 +14,9 @@ class AnchoringMesh(object):
 
     # A towards B
     def __fetch_results(self, fqdn_a, fqdn_b, af, t, filters):
-        anchor_a = self.anchors[self.anchors.fqdn == fqdn_a].iloc[0]
-        anchor_b = self.anchors[self.anchors.fqdn == fqdn_b].iloc[0]
+        anchors = AnchorDataFrame.from_api(filters)
+        anchor_a = anchors[anchors.fqdn == fqdn_a].iloc[0]
+        anchor_b = anchors[anchors.fqdn == fqdn_b].iloc[0]
         mesh_measurements_b = anchor_b.fetch_mesh_measurements()
         msm_to_b = mesh_measurements_b[(mesh_measurements_b.af == af) &
                                        (mesh_measurements_b.type == t)].iloc[0]


### PR DESCRIPTION
There are some calls in the `__fetch_results` method in `AnchoringMesh` that are broken; this PR fixes them. The overall design of the two main classes with this module are unclear, though, so there may be a preferred/better way of "fixing" than what I propose here.